### PR TITLE
Adding custom numbering treeprocessor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <junit.version>4.12</junit.version>
+        <jsoup.version>1.10.2</jsoup.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
@@ -64,6 +66,20 @@
             <artifactId>asciidoctorj</artifactId>
             <version>${asciidoctorj.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>${jsoup.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.version>1.5.5</asciidoctorj.version>
         <junit.version>4.12</junit.version>
         <jsoup.version>1.10.2</jsoup.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <asciidoctorj.version>1.5.5</asciidoctorj.version>
+        <asciidoctorj.version>1.6.0-alpha.3</asciidoctorj.version>
         <junit.version>4.12</junit.version>
         <jsoup.version>1.10.2</jsoup.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>

--- a/src/main/java/org/hibernate/infra/asciidoctor/extensions/customnumbering/CustomNumberingProcessor.java
+++ b/src/main/java/org/hibernate/infra/asciidoctor/extensions/customnumbering/CustomNumberingProcessor.java
@@ -56,27 +56,27 @@ public class CustomNumberingProcessor extends Treeprocessor {
 		}
 	}
 
-	private void updateBlockCaption(AbstractBlock block, String title, int sectionNumber, int indexNumber) {
+	private void updateBlockCaption(AbstractBlock block, String title, String sectionNumber, int indexNumber) {
 		RubyObject rubyObject = toRubyObject( block );
 
 		rubyObject.setInstanceVariable( "@caption", RubyString.newString(
 				Ruby.getGlobalRuntime(),
-				String.format( "%s %d.%d: ", title, sectionNumber, indexNumber )
+				String.format( "%s %s.%d: ", title, sectionNumber, indexNumber )
 		) );
 	}
 
-	private int getSectionNumber(AbstractBlock block) {
+	private String getSectionNumber(AbstractBlock block) {
 		// this would only work if :sectnums: is turned on - otherwise for each section it will reset
 		// number to 1
 		RubyObject rubyObject = toRubyObject( block );
-		return (int) rubyObject.getInstanceVariable( "@number" ).toJava( Integer.class );
+		return rubyObject.getInstanceVariable( "@number" ).toString();
 	}
 
 	private RubyObject toRubyObject(AbstractBlock block) {
 		try {
 			Field f = block.delegate().getClass().getDeclaredFields()[1];
 			f.setAccessible( true );
-			return  (RubyObject) f.get( ( block.delegate() ) ) ;
+			return (RubyObject) f.get( ( block.delegate() ) );
 		}
 		catch (IllegalAccessException e) {
 			throw new IllegalStateException( "Is not able to convert to RubyObject. Processor cannot proceed.", e );
@@ -87,9 +87,9 @@ public class CustomNumberingProcessor extends Treeprocessor {
 
 		private AtomicInteger example;
 		private AtomicInteger table;
-		private final int sectionNumber;
+		private final String sectionNumber;
 
-		private NumberingIndexes(int sectionNumber) {
+		private NumberingIndexes(String sectionNumber) {
 			this.sectionNumber = sectionNumber;
 			example = new AtomicInteger( 1 );
 			table = new AtomicInteger( 1 );
@@ -103,11 +103,11 @@ public class CustomNumberingProcessor extends Treeprocessor {
 			return table;
 		}
 
-		public int getSectionNumber() {
+		public String getSectionNumber() {
 			return sectionNumber;
 		}
 
-		public static NumberingIndexes get(int sectionNumber) {
+		public static NumberingIndexes get(String sectionNumber) {
 			return new NumberingIndexes( sectionNumber );
 		}
 	}

--- a/src/main/java/org/hibernate/infra/asciidoctor/extensions/customnumbering/CustomNumberingProcessor.java
+++ b/src/main/java/org/hibernate/infra/asciidoctor/extensions/customnumbering/CustomNumberingProcessor.java
@@ -1,0 +1,115 @@
+/*
+ * Hibernate Infra - Asciidoctor extensions
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.infra.asciidoctor.extensions.customnumbering;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.extension.Treeprocessor;
+import org.jruby.Ruby;
+import org.jruby.RubyObject;
+import org.jruby.RubyString;
+
+/**
+ * Treeprocessor used to change how example and table captions are numbered.
+ * By using this processor numbers will be in format {@code {section_number}.{example_number} },
+ * where {@code example_number} is reset for each section.
+ *
+ * @author Marko Bekhta
+ */
+public class CustomNumberingProcessor extends Treeprocessor {
+
+	public CustomNumberingProcessor() {
+		super();
+	}
+
+	public CustomNumberingProcessor(Map<String, Object> config) {
+		super( config );
+	}
+
+	@Override
+	public Document process(Document document) {
+		document.getBlocks().stream()
+				.filter( abstractBlock -> "section".equalsIgnoreCase( abstractBlock.getNodeName() ) )
+				.forEach( section -> processSection( section, NumberingIndexes.get( getSectionNumber( section ) ) ) );
+		return document;
+	}
+
+	private void processSection(AbstractBlock section, NumberingIndexes indexes) {
+		for ( AbstractBlock block : section.getBlocks() ) {
+			if ( "example".equalsIgnoreCase( block.getNodeName() ) ) {
+				updateBlockCaption( block, "Example", indexes.getSectionNumber(), indexes.getExample().getAndIncrement() );
+			}
+			else if ( "table".equalsIgnoreCase( block.getNodeName() ) ) {
+				updateBlockCaption( block, "Table", indexes.getSectionNumber(), indexes.getTable().getAndIncrement() );
+			}
+			else if ( "section".equalsIgnoreCase( block.getNodeName() ) ) {
+				processSection( block, indexes );
+			}
+		}
+	}
+
+	private void updateBlockCaption(AbstractBlock block, String title, int sectionNumber, int indexNumber) {
+		RubyObject rubyObject = toRubyObject( block );
+
+		rubyObject.setInstanceVariable( "@caption", RubyString.newString(
+				Ruby.getGlobalRuntime(),
+				String.format( "%s %d.%d: ", title, sectionNumber, indexNumber )
+		) );
+	}
+
+	private int getSectionNumber(AbstractBlock block) {
+		// this would only work if :sectnums: is turned on - otherwise for each section it will reset
+		// number to 1
+		RubyObject rubyObject = toRubyObject( block );
+		return (int) rubyObject.getInstanceVariable( "@number" ).toJava( Integer.class );
+	}
+
+	private RubyObject toRubyObject(AbstractBlock block) {
+		try {
+			Field f = block.delegate().getClass().getDeclaredFields()[1];
+			f.setAccessible( true );
+			return  (RubyObject) f.get( ( block.delegate() ) ) ;
+		}
+		catch (IllegalAccessException e) {
+			throw new IllegalStateException( "Is not able to convert to RubyObject. Processor cannot proceed.", e );
+		}
+	}
+
+	private static class NumberingIndexes {
+
+		private AtomicInteger example;
+		private AtomicInteger table;
+		private final int sectionNumber;
+
+		private NumberingIndexes(int sectionNumber) {
+			this.sectionNumber = sectionNumber;
+			example = new AtomicInteger( 1 );
+			table = new AtomicInteger( 1 );
+		}
+
+		public AtomicInteger getExample() {
+			return example;
+		}
+
+		public AtomicInteger getTable() {
+			return table;
+		}
+
+		public int getSectionNumber() {
+			return sectionNumber;
+		}
+
+		public static NumberingIndexes get(int sectionNumber) {
+			return new NumberingIndexes( sectionNumber );
+		}
+	}
+
+}

--- a/src/main/java/org/hibernate/infra/asciidoctor/extensions/customroleblock/DocBookCustomRoleBlockProcessor.java
+++ b/src/main/java/org/hibernate/infra/asciidoctor/extensions/customroleblock/DocBookCustomRoleBlockProcessor.java
@@ -11,8 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.asciidoctor.ast.AbstractBlock;
-import org.asciidoctor.ast.DocumentRuby;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.BlockProcessor;
 import org.asciidoctor.extension.Reader;
 
@@ -32,10 +32,10 @@ public class DocBookCustomRoleBlockProcessor extends BlockProcessor {
 	}
 
 	@Override
-	public Object process(AbstractBlock parent, Reader reader, Map<String, Object> attributes) {
+	public Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
 		List<String> lines = reader.readLines();
 
-		DocumentRuby document = parent.getDocument();
+		Document document = parent.getDocument();
 		String backend = String.valueOf( document.getAttr( "backend" ) );
 
 		if ( !backend.startsWith( "docbook" ) ) {

--- a/src/main/java/org/hibernate/infra/asciidoctor/extensions/savepreprocessed/SavePreprocessedOutputPreprocessor.java
+++ b/src/main/java/org/hibernate/infra/asciidoctor/extensions/savepreprocessed/SavePreprocessedOutputPreprocessor.java
@@ -38,10 +38,9 @@ public class SavePreprocessedOutputPreprocessor extends Preprocessor {
 	}
 
 	@Override
-	public PreprocessorReader process(Document document, PreprocessorReader reader) {
+	public void process(Document document, PreprocessorReader reader) {
 		try {
 			Files.write( Paths.get( OUTPUT_FILE ), filterLines( reader.readLines() ) );
-			return reader;
 		}
 		catch (IOException e) {
 			throw new RuntimeException( "Unable to write the preprocessed file " + OUTPUT_FILE, e );

--- a/src/test/java/org/hibernate/infra/asciidoctor/extensions/customnumbering/ExampleNumberingTest.java
+++ b/src/test/java/org/hibernate/infra/asciidoctor/extensions/customnumbering/ExampleNumberingTest.java
@@ -1,0 +1,68 @@
+/*
+ * Hibernate Infra - Asciidoctor extensions
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.infra.asciidoctor.extensions.customnumbering;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.SafeMode;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+/**
+ * @author Marko Bekhta
+ */
+public class ExampleNumberingTest {
+
+	private static final Pattern EXAMPLE_TITLE_PATTERN = Pattern.compile( "Example [\\d]+\\.[\\d]+: .*" );
+
+	private static Asciidoctor DOCTOR;
+
+	@BeforeClass
+	public static void initAsciidoctor() {
+		DOCTOR = Asciidoctor.Factory.create();
+		DOCTOR.javaExtensionRegistry().treeprocessor( CustomNumberingProcessor.class );
+	}
+
+	@Test
+	public void simpleExampleNumberingTest() throws URISyntaxException, IOException {
+		File file = Paths.get( ExampleNumberingTest.class.getClassLoader().getResource( "test.asciidoc" ).toURI() ).toFile();
+		try ( FileReader reader = new FileReader( file ) ) {
+			StringWriter writer = new StringWriter();
+			DOCTOR.convert( reader, writer, OptionsBuilder.options().safe( SafeMode.SAFE ).asMap() );
+
+			Document convertedDoc = Jsoup.parse( writer.toString() );
+
+			Elements examples = convertedDoc.getElementsByClass( "exampleblock" );
+
+			examples.forEach( this::assertExampleNumbering );
+
+		}
+	}
+
+	private void assertExampleNumbering(Element example) {
+		Element titleDiv = example.child( 0 );
+		Assert.assertTrue( "Class should match", titleDiv.hasClass( "title" ) );
+		Assert.assertTrue( "Example caption should match regexp",
+				EXAMPLE_TITLE_PATTERN.matcher( titleDiv.html() ).matches()
+		);
+
+	}
+}

--- a/src/test/resources/test.asciidoc
+++ b/src/test/resources/test.asciidoc
@@ -17,6 +17,34 @@ public class Foo{
 ----
 ====
 
+.First Table Title
+|===
+|Name of Column 1 |Name of Column 2 |Name of Column 3
+
+|Cell in column 1, row 1
+|Cell in column 2, row 1
+|Cell in column 3, row 1
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+|===
+
+.Second Table Title
+|===
+|Name of Column 1 |Name of Column 2 |Name of Column 3 |Name of Column 4
+
+|Cell in column 1, row 1
+|Cell in column 2, row 1
+|Cell in column 3, row 1
+|Cell in column 4, row 1
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+|Cell in column 4, row 2
+|===
+
 === Some other inner title
 
 .XML example

--- a/src/test/resources/test.asciidoc
+++ b/src/test/resources/test.asciidoc
@@ -1,0 +1,55 @@
+//= Some title
+:sectnums:
+== Some other title
+
+some very useful text which makes no sense.
+
+.Foo class
+====
+
+[source, JAVA]
+----
+public class Foo{
+	void doFoo(){
+		//do nothing ...
+	}
+}
+----
+====
+
+=== Some other inner title
+
+.XML example
+====
+[source, XML]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<rootTag>
+	<property/>
+</rootTag>
+----
+====
+
+== Yet another title
+
+some more of very useful text which makes no sense.
+
+.Another class example
+====
+[source, JAVA]
+----
+public class Bar{
+	void doFoo(){
+		//do nothing ...
+	}
+}
+----
+====
+
+[source, XML]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<rootTag>
+	<values/>
+</rootTag>
+----


### PR DESCRIPTION
hi @gunnarmorling, @gsmet,
so here's a Java version for that numbering extension. But there's one more problem is left with using it .... Because of the Asciidoctorj's `NodeConverter` tables cannot be used in sources. As it will fail with something like:

```
......
Caused by: java.lang.IllegalArgumentException: Don't know what to do with a #<Asciidoctor::Table:0x25589735>
	... 55 more
```

I somehow forgot about this one when we talked about why I wrote that Ruby version ...
(here's a related bug to this problem - https://github.com/asciidoctor/asciidoctorj/issues/472).
The issue seems to be fixed from  v1.5.4.1. but there's no asciidoctor-ant that uses such version (or higher)