### PR TITLE
Creating output directories in SavePreprocessedOutputPreprocessor process

### DIFF
--- a/src/main/java/org/hibernate/infra/asciidoctor/extensions/savepreprocessed/SavePreprocessedOutputPreprocessor.java
+++ b/src/main/java/org/hibernate/infra/asciidoctor/extensions/savepreprocessed/SavePreprocessedOutputPreprocessor.java
@@ -8,6 +8,7 @@ package org.hibernate.infra.asciidoctor.extensions.savepreprocessed;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,7 +41,9 @@ public class SavePreprocessedOutputPreprocessor extends Preprocessor {
 	@Override
 	public void process(Document document, PreprocessorReader reader) {
 		try {
-			Files.write( Paths.get( OUTPUT_FILE ), filterLines( reader.readLines() ) );
+			Path filePath = Paths.get( OUTPUT_FILE );
+			Files.createDirectories( filePath.getParent() );
+			Files.write( filePath, filterLines( reader.readLines() ) );
 		}
 		catch (IOException e) {
 			throw new RuntimeException( "Unable to write the preprocessed file " + OUTPUT_FILE, e );


### PR DESCRIPTION
This creates directories needed to create `beanvalidation-specification-full.adoc` if they don't exist. Maven doesn't have a good way to create directories other than calling Ant, so this prevents needing to pre-create the `target/preprocessed` directory.