### PR TITLE
Specify source/output encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
         <asciidoctorj.version>3.0.0</asciidoctorj.version>
         <junit.version>4.13.2</junit.version>
         <jsoup.version>1.18.1</jsoup.version>


### PR DESCRIPTION
to remove warnings like:

> [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!